### PR TITLE
Updated to directly use analogj/lexicon

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,12 @@
-FROM tomfun/lexicon-dehydrated-namecheap
+FROM analogj/lexicon:latest
 
-RUN apt-get update && apt-get install -y cron openssh-client && \
+COPY --from=tomfun/lexicon-dehydrated-namecheap /srv/dehydrated/config /srv/dehydrated/
+
+RUN apt update \
+    && apt install -y bsdmainutils \
+    && apt-get clean \
+    && pip install dns-lexicon[namecheap] \
+    && apt-get install -y cron openssh-client && \
     which cron && \
     rm -rf /etc/cron.*/* && \
     mkdir -p /root/.ssh && \
@@ -8,10 +14,17 @@ RUN apt-get update && apt-get install -y cron openssh-client && \
     ln -s /run/secrets/user_ssh_key /root/.ssh/id_rsa
 
 COPY entrypoint.sh /entrypoint.sh
+RUN chmod 755 /entrypoint.sh
 COPY crontab /etc/crontab
 COPY dehydrated.reload_services.sh reload_services.sh /srv/dehydrated/
 # Override default config with config in this repo
 COPY config /usr/local/etc/dehydrated/
+
+VOLUME /data
+
+ENV PROVIDER=namecheap
+
+ENV PROVIDER_UPDATE_DELAY=300
 
 ENTRYPOINT ["/entrypoint.sh"]
 


### PR DESCRIPTION
tomfun/lexicon-dehydrated-namecheap repository updated to use python:3.9-alpine instead of analogj/lexicon which breaks things here.

To be fixed of actually using python:3.9-alpine